### PR TITLE
Updated old releases repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,8 @@ RUN mkdir -p /var/lock/apache2 /var/run/apache2 /var/log/apache2 /var/www/html \
 ## Install libdb4.6 from lucid
 RUN mkdir -p /tmp/install/ \
     && cd /tmp/install \
-    && wget http://de.archive.ubuntu.com/ubuntu/pool/universe/d/db4.6/libdb4.6_4.6.21-16_amd64.deb \
-    && wget http://de.archive.ubuntu.com/ubuntu/pool/universe/d/db4.6/libdb4.6-dev_4.6.21-16_amd64.deb \
+    && wget http://old-releases.ubuntu.com/ubuntu/pool/universe/d/db4.6/libdb4.6_4.6.21-16_amd64.deb \
+    && wget http://old-releases.ubuntu.com/ubuntu/pool/universe/d/db4.6/libdb4.6-dev_4.6.21-16_amd64.deb \
     && echo "2f03a50d72f66d6c6ac976cb0ff1131a  libdb4.6-dev_4.6.21-16_amd64.deb" > md5sums \
     && md5sum -c md5sums \
     && dpkg -i libdb4.6-dev_4.6.21-16_amd64.deb \


### PR DESCRIPTION
Hi!
I recently used this docker image for a legacy php project. 
In the container building process, some URLs are outdated and some files can't be downloaded.
I've updated to http://de.archive.ubuntu.com/ubuntu/pool/universe/d/db4.6/ (it seems that no longer hosts tese files) to http://old-releases.ubuntu.com/ubuntu/pool/universe/d/db4.6. With this update, the image is created successfully and it works perfectly. 
PS: Thank you for this work, I saved a lot of time creating a new one from scratch.
